### PR TITLE
Checkboxes use ccc-grid instead flexbox

### DIFF
--- a/src/modules/common/components/CheckableTaskList.vue
+++ b/src/modules/common/components/CheckableTaskList.vue
@@ -2,10 +2,7 @@
   <div class="checkable-task-list">
     <ul v-if="data && data.length">
       <li v-for="(item, index) of data" :key="index">
-        <TmCheckbox
-          :checked="item.done"
-          @change="$emit('toggle-check', item)"
-        >
+        <TmCheckbox :checked="item.done" @change="$emit('toggle-check', item)">
           {{ item.title }}
         </TmCheckbox>
       </li>
@@ -20,16 +17,15 @@ import { TmCheckbox } from '@/modules/ui-kit'
 
 export default {
   components: {
-    TmCheckbox,
+    TmCheckbox
   },
 
   props: {
     data: {
       type: Array,
       required: true
-    },
-  },
-
+    }
+  }
 }
 </script>
 

--- a/src/modules/ui-kit/components/TmCheckbox.vue
+++ b/src/modules/ui-kit/components/TmCheckbox.vue
@@ -1,14 +1,15 @@
 <template>
   <label class="tm-checkbox">
-    <input type="checkbox"
+    <input
+      type="checkbox"
       :checked="checked"
       @change="$emit('change', $event)"
-    >
+    />
 
     <div class="text">
       <slot />
     </div>
-  </label>  
+  </label>
 </template>
 
 <script>
@@ -17,20 +18,15 @@ export default {
     checked: {
       type: Boolean
     }
-  },
-
+  }
 }
 </script>
 
 <style lang="scss" scoped>
 .tm-checkbox {
   cursor: pointer;
-  display: flex;
-  align-items: baseline;
-}
-
-input {
-  flex-basis: 12px;
+  display: grid;
+  grid-template-columns: 20px 1fr;
 }
 
 .text {


### PR DESCRIPTION
Because checkbox layout breaks on the phones, I prefer to use css-grid instead flexbox to render it.